### PR TITLE
Add has() for zshrc

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -105,24 +105,29 @@ alias sd='pnpm start:dev'
 alias dd='pnpm dev'
 alias bb='pnpm build'
 
-if hash exa 2>/dev/null; then
+# return exit code 0 if command exists
+has() {
+	hash "$1" &>/dev/null
+}
+
+if has exa; then
 	alias ls="exa -l -a -h -F --group-directories-first --icons"
 fi
 
-if hash nvim 2>/dev/null; then
-	alias vim="nvim" 
+if has nvim; then
+	alias vim="nvim"
 fi
 
-if hash gh 2>/dev/null; then
-	alias ghb="gh browse" 
+if has gh; then
+	alias ghb="gh browse"
 	alias opr="gh pr create --web"
 fi
 
-if hash bat 2>/dev/null; then
+if has bat; then
 	alias cat="bat"
 fi
 
-if hash flutter 2>/dev/null; then
-  # export FLUTTER_ROOT="$(asdf where flutter)"
-  export PATH="$(asdf where flutter)/bin":"$PATH"
+if has flutter; then
+	# export FLUTTER_ROOT="$(asdf where flutter)"
+	export PATH="$(asdf where flutter)/bin":"$PATH"
 fi


### PR DESCRIPTION
Add a `has` function so you don't have to use `hash somecmd 2>/dev/null` every time you try to see if a specified command exists.